### PR TITLE
perf: Refactor stream-to-string conversion

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -296,6 +296,10 @@ int privmxDrvNet_httpRequest(privmxDrvNet_Http* http, const char* data, int data
         Poco::Net::HTTPResponse response;
         std::istream& stream = http->session->receiveResponse(response);
         std::string result;
+        std::streamsize len = response.getContentLength();
+        if (len != Poco::Net::HTTPMessage::UNKNOWN_CONTENT_LENGTH) {
+            result.reserve(response.getContentLength());
+        }
         Poco::StreamCopier::copyToString(stream, result);
         char* buf = reinterpret_cast<char*>(malloc(result.size()));
         memcpy(buf, result.data(), result.size());

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -295,7 +295,8 @@ int privmxDrvNet_httpRequest(privmxDrvNet_Http* http, const char* data, int data
         os.write(data, datalen).flush();
         Poco::Net::HTTPResponse response;
         std::istream& stream = http->session->receiveResponse(response);
-        std::string result{std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>()};
+        std::string result;
+        Poco::StreamCopier::copyToString(stream, result);
         char* buf = reinterpret_cast<char*>(malloc(result.size()));
         memcpy(buf, result.data(), result.size());
         *statusCode = response.getStatus();


### PR DESCRIPTION
Replaced manual string construction from istreambuf_iterator with Poco::StreamCopier::copyToString for improved readability and reliability.

Reserve string capacity based on response content length to improve
performance and reduce reallocations when reading the HTTP response.